### PR TITLE
Added a launch and config file to be able to control robot arms using…

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -55,6 +55,7 @@ RUN /bin/sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) 
     python-rosdep \
     ros-${DIST}-controller-manager \
     ros-${DIST}-effort-controllers \
+    ros-${DIST}-industrial-core \
     ros-${DIST}-joint-state-publisher \
     ros-${DIST}-joint-state-publisher-gui \
     ros-${DIST}-joy \
@@ -74,11 +75,13 @@ RUN /bin/sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) 
     ros-${DIST}-rviz \
     ros-${DIST}-teleop-tools \
     ros-${DIST}-teleop-twist-keyboard \
+    ros-${DIST}-moveit-opw-kinematics-plugin \
+    ros-${DIST}-trac-ik \
+    ros-${DIST}-industrial-core \
+    ros-${DIST}-trac-ik-kinematics-plugin \
     ros-${DIST}-velodyne-simulator \
  && rosdep init \
  && apt clean
-
-RUN rosdep update
 
 # Get Gazebo 9.
 COPY keys/gazebo.key /tmp/gazebo.key
@@ -92,6 +95,7 @@ RUN /bin/sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable
     lib${GAZ}-dev \
     ros-${DIST}-gazebo-plugins \
     ros-${DIST}-gazebo-ros \
+    ros-${DIST}-gazebo-ros-control \
     ros-${DIST}-xacro \
  && apt clean
 # This seems to be needed to launch Gazebo on this setup
@@ -127,10 +131,13 @@ RUN apt update \
     ros-${DIST}-vision-opencv \
     ros-${DIST}-joint-state-controller \
     ros-${DIST}-joint-state-publisher \
+    ros-${DIST}-joint-state-publisher-gui \
     ros-${DIST}-moveit-simple-controller-manager \
     ros-${DIST}-joint-trajectory-action \
     ros-${DIST}-joint-trajectory-action-tools \
     ros-${DIST}-joint-trajectory-controller \
+    ros-${DIST}-topic-tools \
+    ros-${DIST}-xacro \
  && apt clean
 
 # Install extra tools tools

--- a/project/ekumen/devutils/CMakeLists.txt
+++ b/project/ekumen/devutils/CMakeLists.txt
@@ -1,0 +1,206 @@
+cmake_minimum_required(VERSION 3.0.2)
+project(devutils)
+
+## Compile as C++11, supported in ROS Kinetic and newer
+# add_compile_options(-std=c++11)
+
+## Find catkin macros and libraries
+## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
+## is used, also find other catkin packages
+find_package(catkin REQUIRED COMPONENTS
+  roscpp
+  rospy
+  std_msgs
+)
+
+## System dependencies are found with CMake's conventions
+# find_package(Boost REQUIRED COMPONENTS system)
+
+
+## Uncomment this if the package has a setup.py. This macro ensures
+## modules and global scripts declared therein get installed
+## See http://ros.org/doc/api/catkin/html/user_guide/setup_dot_py.html
+# catkin_python_setup()
+
+################################################
+## Declare ROS messages, services and actions ##
+################################################
+
+## To declare and build messages, services or actions from within this
+## package, follow these steps:
+## * Let MSG_DEP_SET be the set of packages whose message types you use in
+##   your messages/services/actions (e.g. std_msgs, actionlib_msgs, ...).
+## * In the file package.xml:
+##   * add a build_depend tag for "message_generation"
+##   * add a build_depend and a exec_depend tag for each package in MSG_DEP_SET
+##   * If MSG_DEP_SET isn't empty the following dependency has been pulled in
+##     but can be declared for certainty nonetheless:
+##     * add a exec_depend tag for "message_runtime"
+## * In this file (CMakeLists.txt):
+##   * add "message_generation" and every package in MSG_DEP_SET to
+##     find_package(catkin REQUIRED COMPONENTS ...)
+##   * add "message_runtime" and every package in MSG_DEP_SET to
+##     catkin_package(CATKIN_DEPENDS ...)
+##   * uncomment the add_*_files sections below as needed
+##     and list every .msg/.srv/.action file to be processed
+##   * uncomment the generate_messages entry below
+##   * add every package in MSG_DEP_SET to generate_messages(DEPENDENCIES ...)
+
+## Generate messages in the 'msg' folder
+# add_message_files(
+#   FILES
+#   Message1.msg
+#   Message2.msg
+# )
+
+## Generate services in the 'srv' folder
+# add_service_files(
+#   FILES
+#   Service1.srv
+#   Service2.srv
+# )
+
+## Generate actions in the 'action' folder
+# add_action_files(
+#   FILES
+#   Action1.action
+#   Action2.action
+# )
+
+## Generate added messages and services with any dependencies listed here
+# generate_messages(
+#   DEPENDENCIES
+#   std_msgs
+# )
+
+################################################
+## Declare ROS dynamic reconfigure parameters ##
+################################################
+
+## To declare and build dynamic reconfigure parameters within this
+## package, follow these steps:
+## * In the file package.xml:
+##   * add a build_depend and a exec_depend tag for "dynamic_reconfigure"
+## * In this file (CMakeLists.txt):
+##   * add "dynamic_reconfigure" to
+##     find_package(catkin REQUIRED COMPONENTS ...)
+##   * uncomment the "generate_dynamic_reconfigure_options" section below
+##     and list every .cfg file to be processed
+
+## Generate dynamic reconfigure parameters in the 'cfg' folder
+# generate_dynamic_reconfigure_options(
+#   cfg/DynReconf1.cfg
+#   cfg/DynReconf2.cfg
+# )
+
+###################################
+## catkin specific configuration ##
+###################################
+## The catkin_package macro generates cmake config files for your package
+## Declare things to be passed to dependent projects
+## INCLUDE_DIRS: uncomment this if your package contains header files
+## LIBRARIES: libraries you create in this project that dependent projects also need
+## CATKIN_DEPENDS: catkin_packages dependent projects also need
+## DEPENDS: system dependencies of this project that dependent projects also need
+catkin_package(
+#  INCLUDE_DIRS include
+#  LIBRARIES devutils
+#  CATKIN_DEPENDS roscpp rospy std_msgs
+#  DEPENDS system_lib
+)
+
+###########
+## Build ##
+###########
+
+## Specify additional locations of header files
+## Your package locations should be listed before other locations
+include_directories(
+# include
+  ${catkin_INCLUDE_DIRS}
+)
+
+## Declare a C++ library
+# add_library(${PROJECT_NAME}
+#   src/${PROJECT_NAME}/devutils.cpp
+# )
+
+## Add cmake target dependencies of the library
+## as an example, code may need to be generated before libraries
+## either from message generation or dynamic reconfigure
+# add_dependencies(${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+
+## Declare a C++ executable
+## With catkin_make all packages are built within a single CMake context
+## The recommended prefix ensures that target names across packages don't collide
+# add_executable(${PROJECT_NAME}_node src/devutils_node.cpp)
+
+## Rename C++ executable without prefix
+## The above recommended prefix causes long target names, the following renames the
+## target back to the shorter version for ease of user use
+## e.g. "rosrun someones_pkg node" instead of "rosrun someones_pkg someones_pkg_node"
+# set_target_properties(${PROJECT_NAME}_node PROPERTIES OUTPUT_NAME node PREFIX "")
+
+## Add cmake target dependencies of the executable
+## same as for the library above
+# add_dependencies(${PROJECT_NAME}_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+
+## Specify libraries to link a library or executable target against
+# target_link_libraries(${PROJECT_NAME}_node
+#   ${catkin_LIBRARIES}
+# )
+
+#############
+## Install ##
+#############
+
+# all install targets should use catkin DESTINATION variables
+# See http://ros.org/doc/api/catkin/html/adv_user_guide/variables.html
+
+## Mark executable scripts (Python etc.) for installation
+## in contrast to setup.py, you can choose the destination
+# catkin_install_python(PROGRAMS
+#   scripts/my_python_script
+#   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+# )
+
+## Mark executables for installation
+## See http://docs.ros.org/melodic/api/catkin/html/howto/format1/building_executables.html
+# install(TARGETS ${PROJECT_NAME}_node
+#   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+# )
+
+## Mark libraries for installation
+## See http://docs.ros.org/melodic/api/catkin/html/howto/format1/building_libraries.html
+# install(TARGETS ${PROJECT_NAME}
+#   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+#   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+#   RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
+# )
+
+## Mark cpp header files for installation
+# install(DIRECTORY include/${PROJECT_NAME}/
+#   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+#   FILES_MATCHING PATTERN "*.h"
+#   PATTERN ".svn" EXCLUDE
+# )
+
+## Mark other files for installation (e.g. launch and bag files, etc.)
+# install(FILES
+#   # myfile1
+#   # myfile2
+#   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+# )
+
+#############
+## Testing ##
+#############
+
+## Add gtest based cpp test target and link libraries
+# catkin_add_gtest(${PROJECT_NAME}-test test/test_devutils.cpp)
+# if(TARGET ${PROJECT_NAME}-test)
+#   target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
+# endif()
+
+## Add folders to be run by python nosetests
+# catkin_add_nosetests(test)

--- a/project/ekumen/devutils/config/sample-test.yaml
+++ b/project/ekumen/devutils/config/sample-test.yaml
@@ -1,0 +1,128 @@
+# Competition configuration options
+options:
+  insert_models_over_bins: false
+  insert_models_over_stations: false
+  belt_population_cycles: 1
+
+agv_infos:
+  agv1:
+    location: AS3
+    products:
+      part_0:
+        type: assembly_battery_blue
+        pose:
+          xyz: [0.2, -0.15, 0]
+          rpy: [0, 0, '-pi/4']
+  agv2:
+    location: KS2
+    products:
+      part_0:
+        type: assembly_battery_blue
+        pose:
+          xyz: [0.2, -0.15, 0]
+          rpy: [0, 0, 'pi/4']
+  agv3:
+    location: KS3
+    # products:
+    #   part_0:
+    #     type: assembly_pump_blue
+    #     pose:
+    #       xyz: [0.2, -0.15, 0]
+    #       rpy: [0, 0, 'pi/4']
+  agv4:
+    location: KS4
+    
+orders:
+  # Example for tasking one robot to do assembly and one robot to do kitting
+  order_0:
+    kitting_robot: on
+    assembly_robot: on
+    announcement_condition: time
+    announcement_condition_value: 0.0
+    kitting:
+      shipment_count: 1
+      agvs: [agv2]
+      destinations: [AS1]
+      products:
+        part_0:
+          type: assembly_battery_blue
+          pose:
+            xyz: [0.2, -0.15, 0]
+            rpy: [0, 0, 'pi/4']
+    assembly:
+      shipment_count: 1
+      stations: [AS3]
+      products:
+        part_0:
+          type: assembly_battery_blue
+          pose:
+            xyz: [-0.032465, 0.174845, 0.15]
+            rpy: [0, 0, 0]
+          
+models_over_bins:
+  #  bin1:
+  #    models:
+  #      assembly_regulator_red:
+  #        xyz_start: [0.2, 0.2, 0.0]
+  #        xyz_end: [0.4, 0.4, 0.0]
+  #        rpy: [0, 0, 0]
+  #        num_models_x: 2
+  #        num_models_y: 2
+   bin2:
+     models:
+       assembly_battery_blue:
+         xyz_start: [0.2, 0.2, 0.0]
+         xyz_end: [0.4, 0.4, 0.0]
+         rpy: [0, 0, 0]
+         num_models_x: 2
+         num_models_y: 2
+  #  bin3:
+  #    models:
+  #      assembly_pump_green:
+  #        xyz_start: [0.2, 0.2, 0.0]
+  #        xyz_end: [0.4, 0.4, 0.0]
+  #        rpy: [0, 0, 0]
+  #        num_models_x: 2
+  #        num_models_y: 2
+  #  bin4:
+  #    models:
+  #      assembly_battery_red:
+  #        xyz_start: [0.2, 0.2, 0.0]
+  #        xyz_end: [0.4, 0.4, 0.0]
+  #        rpy: [0, 0, 'pi/4']
+  #        num_models_x: 2
+  #        num_models_y: 1
+
+models_over_stations:
+  station1:
+    models:
+      assembly_battery_green:
+        xyz: [-0.032465, 0.174845, 0.15]
+        rpy: [0, 0, 0]
+      assembly_pump_red:
+        xyz: [0.032085, -0.152835, 0.15]
+        rpy: [0, 0, 0]
+  station2:
+    models:
+      assembly_battery_red:
+        xyz: [-0.032465, 0.174845, 0.15]
+        rpy: [0, 0, 0]
+  station3:
+    models:
+      assembly_pump_blue:
+        xyz: [0.032085, -0.152835, 0.25]
+        rpy: [0, 0, 0]
+ 
+# belt_models:
+#   piston_rod_part_blue:
+#     1.0:
+#       pose:
+#         xyz: [0.0, 4.3, 0.92]
+#         rpy: [0, 0, 'pi/2']
+#   gear_part_red:
+#     2.0:
+#       pose:
+#         xyz: [0.0, 4.3, 0.92]
+#         rpy: [0, 0, 'pi/2']
+
+time_limit: -1

--- a/project/ekumen/devutils/launch/rviz_control_gantry.launch
+++ b/project/ekumen/devutils/launch/rviz_control_gantry.launch
@@ -1,0 +1,7 @@
+<launch>
+  <group ns='ariac/gantry'>
+    <include file="$(find gantry2021_moveit_config)/launch/moveit_rviz.launch">
+      <arg name="rviz_config" value="$(find gantry2021_moveit_config)/launch/moveit.rviz"/>
+    </include>
+  </group>
+</launch>

--- a/project/ekumen/devutils/launch/rviz_control_kitting.launch
+++ b/project/ekumen/devutils/launch/rviz_control_kitting.launch
@@ -1,0 +1,7 @@
+<launch>
+  <group ns='ariac/kitting'>
+    <include file="$(find kitting2021_moveit_config)/launch/moveit_rviz.launch">
+      <arg name="rviz_config" value="$(find kitting2021_moveit_config)/launch/moveit.rviz"/>
+    </include>
+  </group>
+</launch>

--- a/project/ekumen/devutils/launch/sample_environment.launch
+++ b/project/ekumen/devutils/launch/sample_environment.launch
@@ -1,0 +1,33 @@
+<launch>
+  <arg name="verbose" default="false" />
+  <arg unless="$(arg verbose)" name="verbose_args" value="" />
+  <arg     if="$(arg verbose)" name="verbose_args" value="--verbose" />
+
+  <arg name="state_logging" default="false" />
+  <arg unless="$(arg state_logging)" name="state_logging_args" value="" />
+  <arg     if="$(arg state_logging)" name="state_logging_args" value="--state-logging=true" />
+
+  <arg name="no_gui" default="false" />
+  <arg unless="$(arg no_gui)" name="gui_args" value="" />
+  <arg     if="$(arg no_gui)" name="gui_args" value="--no-gui" />
+
+  <arg name="fill_demo_shipment" default="false" />
+  <arg unless="$(arg fill_demo_shipment)" name="fill_demo_shipment_args" value="" />
+  <arg     if="$(arg fill_demo_shipment)" name="fill_demo_shipment_args" value="--fill-demo-shipment" />
+
+  <arg name="load_moveit" default="true" />
+  <arg unless="$(arg load_moveit)" name="load_moveit_args" value="" />
+  <arg     if="$(arg load_moveit)" name="load_moveit_args" value="--load-moveit" />
+
+  <node name="ariac_sim" pkg="nist_gear" type="gear2021.py"
+        args="--development-mode
+          $(arg verbose_args)
+          $(arg state_logging_args)
+          $(arg gui_args)
+          $(arg load_moveit_args)
+          $(arg fill_demo_shipment_args)
+          --visualize-sensor-views
+          -f $(find devutils)/config/sample-test.yaml
+          $(find nist_gear)/config/sample_user_config.yaml
+          " required="true" output="screen" />
+</launch>

--- a/project/ekumen/devutils/package.xml
+++ b/project/ekumen/devutils/package.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>devutils</name>
+  <version>0.0.0</version>
+  <description>The devutils package</description>
+
+  <!-- One maintainer tag required, multiple allowed, one person per tag -->
+  <!-- Example:  -->
+  <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
+  <maintainer email="developer@todo.todo">developer</maintainer>
+
+
+  <!-- One license tag required, multiple allowed, one license per tag -->
+  <!-- Commonly used license strings: -->
+  <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
+  <license>TODO</license>
+
+
+  <!-- Url tags are optional, but multiple are allowed, one per tag -->
+  <!-- Optional attribute type can be: website, bugtracker, or repository -->
+  <!-- Example: -->
+  <!-- <url type="website">http://wiki.ros.org/devutils</url> -->
+
+
+  <!-- Author tags are optional, multiple are allowed, one per tag -->
+  <!-- Authors do not have to be maintainers, but could be -->
+  <!-- Example: -->
+  <!-- <author email="jane.doe@example.com">Jane Doe</author> -->
+
+
+  <!-- The *depend tags are used to specify dependencies -->
+  <!-- Dependencies can be catkin packages or system dependencies -->
+  <!-- Examples: -->
+  <!-- Use depend as a shortcut for packages that are both build and exec dependencies -->
+  <!--   <depend>roscpp</depend> -->
+  <!--   Note that this is equivalent to the following: -->
+  <!--   <build_depend>roscpp</build_depend> -->
+  <!--   <exec_depend>roscpp</exec_depend> -->
+  <!-- Use build_depend for packages you need at compile time: -->
+  <!--   <build_depend>message_generation</build_depend> -->
+  <!-- Use build_export_depend for packages you need in order to build against this package: -->
+  <!--   <build_export_depend>message_generation</build_export_depend> -->
+  <!-- Use buildtool_depend for build tool packages: -->
+  <!--   <buildtool_depend>catkin</buildtool_depend> -->
+  <!-- Use exec_depend for packages you need at runtime: -->
+  <!--   <exec_depend>message_runtime</exec_depend> -->
+  <!-- Use test_depend for packages you need only for testing: -->
+  <!--   <test_depend>gtest</test_depend> -->
+  <!-- Use doc_depend for packages you need only for building documentation: -->
+  <!--   <doc_depend>doxygen</doc_depend> -->
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>roscpp</build_depend>
+  <build_depend>rospy</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <build_export_depend>roscpp</build_export_depend>
+  <build_export_depend>rospy</build_export_depend>
+  <build_export_depend>std_msgs</build_export_depend>
+  <exec_depend>roscpp</exec_depend>
+  <exec_depend>rospy</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+
+
+  <!-- The export tag contains other, unspecified, tags -->
+  <export>
+    <!-- Other tools can request additional information be placed here -->
+
+  </export>
+</package>


### PR DESCRIPTION
… rviz+moveit

This commits adds some missing packages, and creates a modified launch file with an updated sample environment configuration, to step around an error in the setup provided by the organization:

The sample environment used for sample_environment.yaml includes two models for components in the belt which are not availalable and causes the simulation to take a long time to load. This causes the controller spawner to timeout trying to contact the controller service (which is still being loaded), and fail, rendering the simulation, once loaded, unable to be controlled using moveit.

This PR creates a slightly different launch file for the sample environment which has no missing models. This reduced the load file, loading without errors and allowing basic control from the moveit planner interface in rviz.