### PR TITLE
Remove cache from workflow

### DIFF
--- a/.github/workflows/devel_docker_build_and_test.yaml
+++ b/.github/workflows/devel_docker_build_and_test.yaml
@@ -14,11 +14,6 @@ jobs:
     name: Update development environment
     runs-on: ubuntu-runner-lima-1
     steps:
-      - name: Setup ccache action/cache
-        uses: actions/cache@v2
-        with:
-          path: $HOME/.docker_ccache
-          key: ccache
       - uses: actions/checkout@v2
         with:
           submodules: true
@@ -26,7 +21,7 @@ jobs:
         run: |
           cd docker
           ./build.bash
-      - name: Build and test
+      - name: Build and test ARIAC competition workspace
         run: |
           cd docker
           ./cirun.bash

--- a/docker/cirun.bash
+++ b/docker/cirun.bash
@@ -14,10 +14,10 @@ LOCAL_REPO_PATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../" >/dev/null 2>&1 &&
 USERID=$(id -u)
 GROUPID=$(id -g)
 
-mkdir -p $HOME/.docker_ccache
+mkdir -p $HOME/.ci_docker_ccache
 
 docker run \
-  --mount type=bind,source=$HOME/.docker_ccache,target=/home/developer/.ccache \
+  --mount type=bind,source=$HOME/.ci_docker_ccache,target=/home/developer/.ccache \
   --mount type=bind,source=${LOCAL_REPO_PATH},target=/home/developer/ws/src/workspace \
   --runtime=$RUNTIME \
   --rm \


### PR DESCRIPTION
This is triggered because the github action for caching does not seem to be doing anything in particular in the workflow. ccache is just using a folder in the host mounted by the runner script directly. 

The total lack of isolation between the runner and the rest of the host suggests it's better to just mount a cache folder in the host directly, for any branch. That's easily true for ccache, but might not be true for other types of cache.